### PR TITLE
hard coded sendgrid credentials

### DIFF
--- a/config/configuration.yml
+++ b/config/configuration.yml
@@ -210,8 +210,8 @@ production:
     port: 25
     authentication: :plain
     domain: "heroku.com" 
-    user_name: <%= ENV['SENDGRID_USERNAME'] %>
-    password: <%= ENV['SENDGRID_PASSWORD'] %>
+    user_name: "app29610092@heroku.com"
+    password: "r5wekoza0176"
 
 # specific configuration options for development environment
 # that overrides the default ones


### PR DESCRIPTION
Environment variables for SendGrid were not working. As we had no idea about testing, I put back hard coded credentials in the redmine configuration.

I wanted to try that at the beginning: http://www.codeitive.com/0ySVjXjWgV/redmine-email-configuration-with-environment-variables.html

But it is more important to make it just work as before for now...
